### PR TITLE
Fix keyboard arrow keys not updating timeline ticks

### DIFF
--- a/src/main_frame.cpp
+++ b/src/main_frame.cpp
@@ -862,6 +862,9 @@ void MainFrame::AdvanceFrame(int dir)
 		state.frame = 0;
 	else if(seq && state.frame >= seq->frames.size())
 		state.frame = seq->frames.size()-1;
+
+	// Sync ticks when seeking with keyboard
+	state.currentTick = CalculateTickFromFrame(&active->frameData, state.pattern, state.frame);
 }
 
 void MainFrame::UpdateBackProj(float x, float y)


### PR DESCRIPTION
## Fixes #1 - Keyboard Arrow Keys Now Update Timeline
  Ticks

  ### Summary
  Fixed a bug where pressing Left/Right arrow keys on
  the keyboard would advance frames but fail to update
  the timeline and Effect Tick display in the bottom
  pane.

  ### Problem
  - **UI Arrow Buttons**: ✅ Updated both frame counter
  AND tick position
  - **Keyboard Arrow Keys**: ❌ Only updated frame
  counter, tick position stayed frozen
  - This caused the timeline visualization to desync
  when using keyboard navigation

  ### Root Cause
  The `AdvanceFrame()` function in `src/main_frame.cpp`
  (called by keyboard shortcuts) only updated
  `state.frame` but didn't call
  `CalculateTickFromFrame()` to sync
  `state.currentTick`.

  The UI arrow button handlers in `main_pane.cpp`
  correctly called `CalculateTickFromFrame()` after
  changing frames.

  ### Solution
  Added tick synchronization to `AdvanceFrame()`:

  **File: `src/main_frame.cpp:867`**
  ```cpp
  // Sync ticks when seeking with keyboard
  state.currentTick = 
  CalculateTickFromFrame(&active->frameData, 
  state.pattern, state.frame);

  How It Works

  The tick system handles variable frame durations
  correctly:
  - Each frame has a duration property (in ticks)
  - CalculateTickFromFrame() sums all frame durations
  from 0 to the current frame
  - This gives the correct tick position for patterns
  with varying frame durations

  Example:
  - Frame 0: duration = 5 ticks → tick position 0
  - Frame 1: duration = 3 ticks → tick position 5
  - Frame 2: duration = 10 ticks → tick position 8

  Testing

  - Build succeeds without errors
  - Keyboard Left/Right now behaves identically to UI
  arrow buttons
  - Timeline scrubber position updates correctly with
  keyboard navigation
  - Works with patterns that have varying frame
  durations

  Files Changed

  - src/main_frame.cpp - Added tick sync to keyboard
  navigation handler