### PR TITLE
Fix tick position not resetting when changing patterns

### DIFF
--- a/src/main_frame.cpp
+++ b/src/main_frame.cpp
@@ -847,6 +847,7 @@ void MainFrame::AdvancePattern(int dir)
 	else if(state.pattern >= active->frameData.get_sequence_count())
 		state.pattern = active->frameData.get_sequence_count()-1;
 	state.frame = 0;
+	state.currentTick = 0;  // Reset tick when changing pattern
 }
 
 void MainFrame::AdvanceFrame(int dir)

--- a/src/main_pane.cpp
+++ b/src/main_pane.cpp
@@ -63,6 +63,7 @@ void MainPane::Draw()
 				{
 					currState.pattern = n;
 					currState.frame = 0;
+					currState.currentTick = 0;  // Reset tick when changing pattern
 				}
 
 				// Set the initial focus when opening the combo (scrolling + keyboard navigation focus)


### PR DESCRIPTION
Resolves #5

  When changing patterns via dropdown or Up/Down
  keyboard shortcuts,
  the frame counter was correctly reset to 0 but the
  tick counter
  remained at its previous value, causing timeline
  desync.

  Added currentTick = 0 to both pattern change
  locations:
  - Pattern dropdown selection in main_pane.cpp
  - AdvancePattern() keyboard handler in main_frame.cpp