### PR TITLE
fixes for issue 19 Paste all transforms does not paste Z priority #19

### DIFF
--- a/src/main_pane.cpp
+++ b/src/main_pane.cpp
@@ -371,6 +371,7 @@ void MainPane::Draw()
 							memcpy(seq->frames[i].AF.rgba, frame.AF.rgba, sizeof(float)*4);
 							seq->frames[i].AF.blend_mode = frame.AF.blend_mode;
 							seq->frames[i].AF.AFRT = frame.AF.AFRT;
+							seq->frames[i].AF.priority = frame.AF.priority;
 						}
 						frameData->mark_modified(currState.pattern);
 						markModified();


### PR DESCRIPTION
Fixed issue #19 where the "Paste all transforms"
  button was not pasting the Z-priority (rendering
  depth) value.

  Changes

  - Added AF.priority to the list of properties copied
  by the "Paste all transforms" button in
  src/main_pane.cpp
  - The button now properly copies all transform-related
   visual properties including Z-priority

  Technical Details

  The "Paste all transforms" button now pastes:
  - Position offsets (X/Y)
  - Rotation (3-axis)
  - Scale (X/Y)
  - Color (RGBA)
  - Blend mode
  - Rotation type flag (AFRT)
  - Z-Priority ✨ (previously missing)

  This makes the button consistent with its name and
  purpose - copying all transform properties that affect
   visual rendering.