### PR TITLE
Fix for Issue #6

### DIFF
--- a/src/main_pane.cpp
+++ b/src/main_pane.cpp
@@ -130,7 +130,7 @@ void MainPane::Draw()
 				
 			}
 
-			im::BeginChild("FrameInfo", {0, im::GetWindowSize().y-im::GetFrameHeight()*3}, false, ImGuiWindowFlags_HorizontalScrollbar);
+			im::BeginChild("FrameInfo", {0, 0}, false);
 
 			// Show if current pattern is modified
 			if(seq->modified)


### PR DESCRIPTION
 Problem: The "Left Pane" window had two overlapping
  scrollbars - one from the parent window and one from
  the "FrameInfo" child window.

  Root Cause: Line 133 was creating a child window with:
  - Fixed height: im::GetWindowSize().y-im::GetFrameHeight()*3
  - ImGuiWindowFlags_HorizontalScrollbar flag

  This caused the child to have its own scrolling region
   separate from the parent.

  Solution: Changed line 133 from:
  im::BeginChild("FrameInfo", {0,
  im::GetWindowSize().y-im::GetFrameHeight()*3}, false,
  ImGuiWindowFlags_HorizontalScrollbar);

  To:
  im::BeginChild("FrameInfo", {0, 0}, false);

  By setting the height to 0, ImGui automatically fills
  the remaining space in the parent window without
  creating an independent scrolling region. This removes
   the horizontal scrollbar flag and lets the parent
  window handle all scrolling, eliminating the double
  scrollbar issue.