### PR TITLE
Add tooltips for flagsets in effect_actor.h

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -7,7 +7,8 @@
       "Read(//mnt/c/games/qoh/**)",
       "Bash(gh issue list:*)",
       "Bash(gh issue view:*)",
-      "Bash(cat:*)"
+      "Bash(cat:*)",
+      "Bash(/dev/null)"
     ],
     "deny": [],
     "ask": []

--- a/src/frame_disp/effects/effect_actor.h
+++ b/src/frame_disp/effects/effect_actor.h
@@ -43,21 +43,57 @@ static inline void DrawEffectActor_Type8(Frame_EF& effect, FrameData* frameData,
 				markModified();
 			}
 
-			// Show flagsets collapsed
-			if(im::TreeNode("Flagset 1 (same as Type 1)")) {
+			// Flagset 1
+			if(im::TreeNode("Flagset 1 (Spawn Behavior)")) {
 				unsigned int flagIdx = -1;
 				if(BitField("##flags1", (unsigned int*)&p[2], &flagIdx, 13)) {
 					markModified();
 				}
+
+				// Tooltips based on hovered flag
+				switch(flagIdx) {
+					case 0: Tooltip("Remove when parent gets hit (includes shield, throw, not clash/armor)"); break;
+					case 1: Tooltip("Always face right"); break;
+					case 2: Tooltip("Follow parent"); break;
+					case 3: Tooltip("Affected by hitstop of parent"); break;
+					case 4: Tooltip("Coordinates relative to camera"); break;
+					case 5: Tooltip("Remove when parent changes pattern"); break;
+					case 6: Tooltip("Can go below floor level"); break;
+					case 7: Tooltip("Always on floor"); break;
+					case 8: Tooltip("Inherit parent's rotation"); break;
+					case 9: Tooltip("Position relative to screen border in the back"); break;
+					case 10: Tooltip("Unknown effect"); break;
+					case 11: Tooltip("Flip facing"); break;
+					case 12: Tooltip("Unknown (Akiha's 217 only)"); break;
+				}
+
 				im::Text("Raw value: %d", p[2]);
 				im::TreePop();
 			}
 
-			if(im::TreeNode("Flagset 2 (same as Type 1)")) {
+			// Flagset 2
+			if(im::TreeNode("Flagset 2 (Child Properties)")) {
 				unsigned int flagIdx = -1;
 				if(BitField("##flags2", (unsigned int*)&p[3], &flagIdx, 13)) {
 					markModified();
 				}
+
+				// Tooltips based on hovered flag
+				switch(flagIdx) {
+					case 0: Tooltip("Child has shadow"); break;
+					case 1: Tooltip("Advance child with parent (also activates Flagset 1 bit 5)"); break;
+					case 2: Tooltip("Remove when parent is thrown"); break;
+					case 3: Tooltip("Parent is affected by hitstop"); break;
+					case 4: case 5: Tooltip("Unknown effect"); break;
+					case 6: Tooltip("Unaffected by parent's Type 2 superflash if spawned during it"); break;
+					case 7: Tooltip("Doesn't move with camera"); break;
+					case 8: Tooltip("Position is relative to opponent"); break;
+					case 9: Tooltip("Position is relative to (-32768, 0)"); break;
+					case 10: Tooltip("Top Z Priority (overridden if projectile sets own priority)"); break;
+					case 11: Tooltip("Face according to player slot"); break;
+					case 12: Tooltip("Unaffected by any superflash"); break;
+				}
+
 				im::Text("Raw value: %d", p[3]);
 				im::TreePop();
 			}


### PR DESCRIPTION
Enhanced the UI for Flagset 1 and Flagset 2 in DrawEffectActor_Type8 by providing contextual tooltips for each flag when hovered. Also updated flagset labels for clarity. 

fixes for #36 